### PR TITLE
Add "simple" search element

### DIFF
--- a/src/Models/Elements/ElementalExtensibleSimpleSearch.php
+++ b/src/Models/Elements/ElementalExtensibleSimpleSearch.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace NSWDPC\Elemental\Models\ExtensibleSearch;
+
+use DNADesign\Elemental\Models\BaseElement;
+use nglasl\extensible\ExtensibleSearchPage;
+
+/**
+ * Simple search element, from which other search elements can be based,
+ * linked to an {@link nglasl\extensible\ExtensibleSearchPage}
+ *
+ * Using an extensible search page as configuration
+ *
+ * @author Mark
+ * @author James
+ */
+class ElementalExtensibleSimpleSearch extends BaseElement
+{
+
+    use SearchElement;
+
+    /**
+     * @inheritdoc
+     */
+    private static $icon = "font-icon-search";
+
+    /**
+     * @inheritdoc
+     */
+    private static $table_name = "ElementalExtensibleSimpleSearch";
+
+    /**
+     * @inheritdoc
+     */
+    private static $title = "Search";
+
+    /**
+     * @inheritdoc
+     */
+    private static $description = "Display a search block";
+
+    /**
+     * @inheritdoc
+     */
+    private static $singular_name = "Search";
+
+    /**
+     * @inheritdoc
+     */
+    private static $plural_name = "Searches";
+
+    /**
+     * @inheritdoc
+     */
+    private static $inline_editable = true;
+
+    /**
+     * @inheritdoc
+     */
+    private static $has_one = [
+        'SearchPage' => ExtensibleSearchPage::class
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    public function getType()
+    {
+        return _t(
+            __CLASS__ . ".BlockType",
+            "Simple search"
+        );
+    }
+
+}

--- a/src/Models/Elements/ElementalExtensibleSimpleSearch.php
+++ b/src/Models/Elements/ElementalExtensibleSimpleSearch.php
@@ -74,6 +74,13 @@ class ElementalExtensibleSimpleSearch extends BaseElement
     /**
      * @inheritdoc
      */
+    private static $owns = [
+        'Image'
+    ];
+
+    /**
+     * @inheritdoc
+     */
     public function getType()
     {
         return _t(

--- a/src/Models/Elements/ElementalExtensibleSimpleSearch.php
+++ b/src/Models/Elements/ElementalExtensibleSimpleSearch.php
@@ -4,6 +4,7 @@ namespace NSWDPC\Elemental\Models\ExtensibleSearch;
 
 use DNADesign\Elemental\Models\BaseElement;
 use nglasl\extensible\ExtensibleSearchPage;
+use SilverStripe\Assets\Image;
 
 /**
  * Simple search element, from which other search elements can be based,
@@ -37,7 +38,7 @@ class ElementalExtensibleSimpleSearch extends BaseElement
     /**
      * @inheritdoc
      */
-    private static $description = "Display a search block";
+    private static $description = "Display a search field that can be decorated with optional content";
 
     /**
      * @inheritdoc
@@ -57,7 +58,16 @@ class ElementalExtensibleSimpleSearch extends BaseElement
     /**
      * @inheritdoc
      */
+    private static $db = [
+        'Content' => 'Text',
+        'FieldTitle' => 'Varchar(255)'
+    ];
+
+    /**
+     * @inheritdoc
+     */
     private static $has_one = [
+        'Image' => Image::class,
         'SearchPage' => ExtensibleSearchPage::class
     ];
 

--- a/src/Traits/SearchElement.php
+++ b/src/Traits/SearchElement.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace NSWDPC\Elemental\Models\ExtensibleSearch;
+
+
+use nglasl\extensible\ExtensibleSearchPage;
+use SilverStripe\CMS\Controllers\ModelAsController;
+use SilverStripe\CMS\Search\SearchForm;
+
+/**
+ * Reusable methods across extensible search elements
+ *
+ * @author James
+ */
+trait SearchElement {
+
+    /**
+     * Allowed file types for image relation
+     */
+    public function getAllowedFileTypes() : array
+    {
+        $types = $this->config()->get("allowed_file_types");
+        if (empty($types)) {
+            $types = ["jpg", "jpeg", "gif", "png", "webp"];
+        }
+        $types = array_unique($types);
+        return $types;
+    }
+
+    /**
+     * Folder to store images
+     */
+    public function getFolderName() : string
+    {
+        $folder_name = $this->config()->get('folder_name');
+        if (!$folder_name) {
+            $folder_name = "images";
+        }
+        return $folder_name;
+    }
+
+
+    /**
+     * Return search form (or not)
+     */
+    public function getElementSearchForm($request = null, $sorting = false) : ?SearchForm
+    {
+        $page = $this->getSearchPage();
+        if (!$page) {
+            return null;
+        }
+        $searchForm = ModelAsController::controller_for($page)->getSearchForm($request, $sorting);
+        if (!($searchForm instanceof SearchForm)) {
+            return null;
+        } else {
+            return $searchForm;
+        }
+    }
+
+    /**
+     * Return search page, if set
+     */
+    public function getSearchPage() : ?ExtensibleSearchPage
+    {
+        $page = $this->SearchPage();
+        return $page && $page->exists() ? $page : null;
+    }
+
+}

--- a/templates/NSWDPC/Elemental/Models/ExtensibleSearch/ElementalExtensibleSimpleSearch.ss
+++ b/templates/NSWDPC/Elemental/Models/ExtensibleSearch/ElementalExtensibleSimpleSearch.ss
@@ -1,0 +1,28 @@
+<% if $ElementSearchForm %>
+
+    <% with $ElementSearchForm %>
+    <div class="nsw-grid">
+
+        <div class="nsw-col nsw-col-md-8">
+
+            <form role="search" {$FormAttributes}>
+                <% if $Up.ShowTitle && $Up.Title %>
+                <label class="nsw-form__label" for="{$FormName}_Search">{$Up.Title}</label>
+                <% end_if %>
+                <div class="nsw-form__input-group">
+                    <input id="{$FormName}_Search" name="Search" type="search" class="nsw-form__input" value="{$SearchQuery.XML}">
+                    <button class="nsw-button nsw-button--dark nsw-button--flex" type="submit"><%t nswds.SEARCH 'Search' %></button>
+                </div>
+                <% if $HiddenFields %>
+                    <% loop $HiddenFields %>
+                    {$Field}
+                    <% end_loop %>
+                <% end_if %>
+            </form>
+
+        </div>
+
+    </div>
+    <% end_with %>
+
+<% end_if %>

--- a/templates/NSWDPC/Elemental/Models/ExtensibleSearch/ElementalExtensibleSimpleSearch.ss
+++ b/templates/NSWDPC/Elemental/Models/ExtensibleSearch/ElementalExtensibleSimpleSearch.ss
@@ -1,28 +1,23 @@
+<%-- basic template, override in your own project --%>
+
+<% if $ShowTitle && $Title %>
+    <<% if $HeadingLevel %>$HeadingLevel<% else %>h2<% end_if %>>
+        {$Title}
+    </<% if $HeadingLevel %>$HeadingLevel<% else %>h2<% end_if %>>
+<% end_if %>
+
+<% if $Content || $Image %>
+<p>
+<% if $Image %>
+    {$Image.ScaleHeight(96)}
+<% end_if %>
+<% if $Content %>
+    <span>{$Content}</span>
+<% end_if %>
+</p>
+<% end_if %>
+
+
 <% if $ElementSearchForm %>
-
-    <% with $ElementSearchForm %>
-    <div class="nsw-grid">
-
-        <div class="nsw-col nsw-col-md-8">
-
-            <form role="search" {$FormAttributes}>
-                <% if $Up.ShowTitle && $Up.Title %>
-                <label class="nsw-form__label" for="{$FormName}_Search">{$Up.Title}</label>
-                <% end_if %>
-                <div class="nsw-form__input-group">
-                    <input id="{$FormName}_Search" name="Search" type="search" class="nsw-form__input" value="{$SearchQuery.XML}">
-                    <button class="nsw-button nsw-button--dark nsw-button--flex" type="submit"><%t nswds.SEARCH 'Search' %></button>
-                </div>
-                <% if $HiddenFields %>
-                    <% loop $HiddenFields %>
-                    {$Field}
-                    <% end_loop %>
-                <% end_if %>
-            </form>
-
-        </div>
-
-    </div>
-    <% end_with %>
-
+    {$ElementSearchForm}
 <% end_if %>


### PR DESCRIPTION
Adds a "simple" search element containing content, field title, an image and a target search page fields - similar to current but without search links. Unfortunately can't subclass that with this element without migration pain.

Another option is providing a display option to the current element and let the template decide how to render based on that.

What do you think?

